### PR TITLE
Fix SVG loader error

### DIFF
--- a/files/next.config.js
+++ b/files/next.config.js
@@ -30,6 +30,11 @@ module.exports = withPlugins(
         );
       }
 
+      config.module.rules.push({
+        test: /\.svg$/,
+        use: ['@svgr/webpack']
+      });
+
       return config;
     }
   }


### PR DESCRIPTION
I was running into the following error:
```
▶ yarn build
yarn run v1.15.2
$ next build src
Creating an optimized production build ...

Failed to compile.

./components/Logo/logo.svg 1:0
Module parse failed: Unexpected token (1:0)
You may need an appropriate loader to handle this file type.
```
It was missing the SVG loader. I've included into the boilerplate files :) 