### PR TITLE
feat(deps): upgrade Next.js & next-transpile-modules

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,8 +20,8 @@
     "emotion-server": "^10.0.0",
     "emotion-theming": "^10.0.0",
     "lodash": "^4.17.0",
-    "next": "^9.3.0",
-    "next-transpile-modules": "^3.3.0",
+    "next": "^10.0.2",
+    "next-transpile-modules": "^4.1.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   },


### PR DESCRIPTION
This is in regards to an error I got when I tried to build the [Support Center](https://github.com/sumup/support-centre) using the `create-sumup-next-app`(canary build).
Set up the project using the command, but when I tried `yarn dev`, I got the error below.
![image](https://user-images.githubusercontent.com/43965625/99800383-f39b3780-2b3c-11eb-9514-361cdf39885a.png)
![image](https://user-images.githubusercontent.com/43965625/99800465-13326000-2b3d-11eb-86bf-ddf62a302618.png)
![image](https://user-images.githubusercontent.com/43965625/99800476-16c5e700-2b3d-11eb-9727-b699ad7b9d7a.png)

Looked through the internet, and stumbled across [this](https://github.com/vercel/next.js/discussions/14932). So I tried upgrading `next` & `next-transpile-modules` to the latest versions, and it worked! :) So far, besides this warning below, there's no other issue.
![image](https://user-images.githubusercontent.com/43965625/99801021-fba7a700-2b3d-11eb-9d79-ff571699c893.png)

