### PR TITLE
feat: add bundle analyzer plugin

### DIFF
--- a/template/next.config.js
+++ b/template/next.config.js
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
 const withTM = require('next-transpile-modules')([
   '@sumup/circuit-ui',
   '@sumup/design-tokens',
@@ -6,16 +9,18 @@ const withTM = require('next-transpile-modules')([
   '@sumup/icons',
 ]);
 
-module.exports = withTM({
-  /**
-   * Environment variables can be used to inject dynamic configuration
-   * into the Next.js app at built time. Learn more at
-   * https://nextjs.org/docs/api-reference/next.config.js/environment-variables
-   */
-  env: {
-    SITE_NAME: 'SumUp',
-    SITE_LOCALE: 'en',
-    SITE_BASEURL: 'https://example.sumup.com',
-    STATIC_ASSET_BASEURL: 'https://static.sumup.com',
-  },
-});
+module.exports = withBundleAnalyzer(
+  withTM({
+    /**
+     * Environment variables can be used to inject dynamic configuration
+     * into the Next.js app at built time. Learn more at
+     * https://nextjs.org/docs/api-reference/next.config.js/environment-variables
+     */
+    env: {
+      SITE_NAME: 'SumUp',
+      SITE_LOCALE: 'en',
+      SITE_BASEURL: 'https://example.sumup.com',
+      STATIC_ASSET_BASEURL: 'https://static.sumup.com',
+    },
+  }),
+);

--- a/template/package.json
+++ b/template/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "analyze": "ANALYZE=true yarn build",
     "test": "jest --watch",
     "test:ci": "mkdir -p __reports__ && jest --ci --coverage --runInBand --json --outputFile=__reports__/jest-results.json",
     "postinstall": "yarn foundry init; echo \"Remove the postinstall script from the package.json file after setting up Foundry.\""
@@ -13,6 +14,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.0",
     "@emotion/styled": "^10.0.0",
+    "@next/bundle-analyzer": "^10.0.0",
     "@sumup/circuit-ui": "^2.0.0",
     "@sumup/collector": "^1.0.0",
     "@sumup/design-tokens": "^2.0.0",


### PR DESCRIPTION
The [Webpack Bundle Analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) plugin enables developers to inspect the bundles that Webpack generates with an interactive zoomable treemap. This is incredibly helpful to identify and debug performance issues. 

This PR adds the official [Next.js bundle analyzer plugin](https://www.npmjs.com/package/@next/bundle-analyzer). Running `yarn analyze` builds the application in production mode and opens two browser tabs to inspect the server and browser bundles:

_Server:_

<img width="1680" alt="Treemap of the server bundles" src="https://user-images.githubusercontent.com/11017722/101754598-34e78d00-3ad4-11eb-9816-54d528999e34.png">

_Client:_

<img width="1680" alt="Treemap of the client bundles" src="https://user-images.githubusercontent.com/11017722/101754643-3e70f500-3ad4-11eb-839a-e72e47f1d109.png">
